### PR TITLE
5 autogenerated html

### DIFF
--- a/.github/workflows/generate_html.yml
+++ b/.github/workflows/generate_html.yml
@@ -8,16 +8,14 @@ jobs:
     steps:
       - name: Get repo
         uses: actions/checkout@v2
-      - name: Change directory
-        run: cd extensions
       - name: Generate extensions/index.html
         uses: docker://pandoc/core:2.9
         with:
-          args: |
-            --output=index.html
-            --css=github-pandoc.css
+          args: >
+            --output=extensions/index.html
+            --css=extensions/github-pandoc.css
             --standalone
-            index.md
+            extensions/index.md
       - name: Commit extensions/index.html
         uses: EndBug/add-and-commit@v5
         with:

--- a/extensions/index.html
+++ b/extensions/index.html
@@ -12,9 +12,8 @@
     div.column{display: inline-block; vertical-align: top; width: 50%;}
     div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
     ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
-  <link rel="stylesheet" href="github-pandoc.css" />
+  <link rel="stylesheet" href="extensions/github-pandoc.css" />
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->


### PR DESCRIPTION
Since 9578d6cd756b1a133f052d0e59d2f77761d63c15 the extensions/index.html file wasn't autogenerated anymore due to a wrong use of yaml mutiline string.